### PR TITLE
Allow '.' for typename in annotation comment

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -339,5 +339,5 @@ func isIdentifierPrefix(r rune) bool {
 // isTypeDecl reports whether r a character legal in a type declaration, eg map[*Thing]interface{}
 // brackets are a special case, handled in lexTypeParameter
 func isTypeDecl(r rune) bool {
-	return r == '*' || r == '{' || r == '}' || r == '[' || r == ']' || isAlphaNumeric(r)
+	return r == '*' || r == '{' || r == '}' || r == '[' || r == ']' || isAlphaNumeric(r) || r == '.'
 }

--- a/parse.go
+++ b/parse.go
@@ -23,8 +23,10 @@ func getPackages(directive string, conf *Config) ([]*Package, error) {
 		return ignored(f)
 	}
 
-	// get the AST
+	// Get the AST from the files in the current directory
 	fset := token.NewFileSet()
+
+	// The parser.ParseComments is a constant indicating "parse comments and add them to AST"
 	astPkgs, err := parser.ParseDir(fset, "./", filt, parser.ParseComments)
 
 	if err != nil {
@@ -34,6 +36,8 @@ func getPackages(directive string, conf *Config) ([]*Package, error) {
 	var pkgs []*Package
 	var typeCheckErrors []*TypeCheckError
 
+	// For each package ast nodes, filter the tagged comments and parse the
+	// annotation from them.
 	for _, a := range astPkgs {
 		pkg, err := getPackage(fset, a, conf)
 
@@ -238,6 +242,9 @@ func (p *parsr) unexpected(item item) error {
 	return p.errorf(item, "unexpected '%v'", item.val)
 }
 
+/*
+The annotation parser for tagged comments
+*/
 func parse(fset *token.FileSet, comment *ast.Comment, directive string) (Pointer, TagSlice, error) {
 	var pointer Pointer
 	var tags TagSlice


### PR DESCRIPTION
Summary:

For types from other packages, we need to reference the typename with
package name. e.g.,   "ast.Function"

Related Issue: https://github.com/clipperhouse/gen/issues/88
