### PR TITLE
Add support for generation of default methods for empty or * tags

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -177,6 +177,14 @@ func lexTag(l *lexer) stateFn {
 func lexTagValues(l *lexer) stateFn {
 	for {
 		switch r := l.next(); {
+		case r == '*':
+			r2 := l.peek()
+			// r2 has to be either , or ".
+			if !(r2 == ',' || r2 == '"') {
+				return l.errorf("Expected a , or \" after * tag value. Got '%s'", string(r))
+			}
+			l.emit(itemTagValue)
+			return lexTagValues
 		case r == '-':
 			l.emit(itemMinus)
 		case isIdentifierPrefix(r):

--- a/parse_test.go
+++ b/parse_test.go
@@ -69,6 +69,30 @@ func TestParse(t *testing.T) {
 				{"Baz", nil, nil},
 			}, false},
 		}, true},
+
+		// Allow * in tag values to denote "all applicable methods"
+		{`// +test foo:"*"`, false, TagSlice{
+			{"foo", []TagValue{
+				{"*", nil, nil},
+			}, false},
+		}, true},
+		{`// +test foo:"*,Bar"`, false, TagSlice{
+			{"foo", []TagValue{
+				{"*", nil, nil},
+				{"Bar", nil, nil},
+			}, false},
+		}, true},
+		{`// +test foo:"Bar,*"`, false, TagSlice{
+			{"foo", []TagValue{
+				{"Bar", nil, nil},
+				{"*", nil, nil},
+			}, false},
+		}, true},
+
+		// * should not be part of identifiers
+		{`// +test foo:"*a"`, false, nil, false},
+		{`// +test foo:"a*"`, false, nil, false},
+
 		{`// +test * foo:"bar,Baz"`, true, TagSlice{
 			{"foo", []TagValue{
 				{"bar", nil, nil},

--- a/tag.go
+++ b/tag.go
@@ -12,3 +12,55 @@ type TagValue struct {
 	TypeParameters []Type
 	typeParameters []item
 }
+
+// AddDefaultsIfNeeded adds default tag values if either 1) none are
+// specified or 2) if a * is present in the TagValues. The * is removed
+// if it is found.
+func (tag *Tag) AddDefaultsIfNeeded(typ Type, templates TemplateSlice) {
+	if tag.ShouldAddDefaults() {
+		defaults := MakeDefaultTagValues(typ, templates)
+		tag.Values = append(tag.Values, defaults...)
+	}
+	tag.RemoveStars()
+}
+
+// ShouldAddDefaults tells whether the tag calls for adding
+// default methods.
+func (tag *Tag) ShouldAddDefaults() bool {
+	if len(tag.Values) == 0 {
+		return true
+	} else {
+		for _, tv := range tag.Values {
+			if tv.Name == "*" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// RemoveStars removes the TagValues with a Name of "*".
+func (tag *Tag) RemoveStars() {
+	newValues := make([]TagValue, 0)
+	for _, tv := range tag.Values {
+		if tv.Name != "*" {
+			newValues = append(newValues, tv)
+		}
+	}
+	tag.Values = newValues
+}
+
+// MakeDefaultTagValues makes an array of TagValues naming templates
+// compatible with typ that have no type parameters.
+func MakeDefaultTagValues(typ Type, templates TemplateSlice) []TagValue {
+	tagValues := make([]TagValue, 0)
+	for _, tpl := range templates {
+		err := tpl.TypeConstraint.TryType(typ)
+		if err == nil && len(tpl.TypeParameterConstraints) == 0 {
+			tv := TagValue{}
+			tv.Name = tpl.Name
+			tagValues = append(tagValues, tv)
+		}
+	}
+	return tagValues
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,63 @@
+package typewriter
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestShouldAddDefaultsEmptyCase(t *testing.T) {
+	tag := &Tag{}
+	if !tag.ShouldAddDefaults() {
+		t.Error("tag should add defaults if empty")
+	}
+}
+
+func TestShouldAddDefaultsNonEmtpyWithoutStar(t *testing.T) {
+	tag := &Tag{
+		Values: []TagValue{
+			TagValue{Name: "foo"},
+		},
+	}
+	if tag.ShouldAddDefaults() {
+		t.Error("tag should not add defaults for non-empty case without *")
+	}
+}
+
+func TestShouldAddDefaultsNonEmptyWithStar(t *testing.T) {
+	tag := &Tag{
+		Values: []TagValue{
+			TagValue{Name: "*"},
+		},
+	}
+	if !tag.ShouldAddDefaults() {
+		t.Error("tag should add defaults for non-empty case with *")
+	}
+}
+
+func TestMakeDefaultTagValuesEmptyCase(t *testing.T) {
+	tagvals := MakeDefaultTagValues(Type{}, TemplateSlice{})
+	if len(tagvals) != 0 {
+		t.Error("Should get nothing but got something for empty case:", tagvals)
+	}
+}
+
+func TestMakeDefaultTagValuesCaseOneYes(t *testing.T) {
+	templates := TemplateSlice([]*Template{&Template{Name: "foo"}})
+	typ := Type{}
+	defaults := MakeDefaultTagValues(typ, templates)
+	expectedDefaults := []TagValue{
+		TagValue{Name: "foo"},
+	}
+	if !reflect.DeepEqual(expectedDefaults, defaults) {
+		t.Errorf("\nexpectedDefaults:\n%#v\ndefaults:\n%#v\n", expectedDefaults, defaults)
+	}
+}
+
+func TestMakeDefaultTagValuesCaseOneNo(t *testing.T) {
+	templates := TemplateSlice([]*Template{&Template{Name: "foo", TypeConstraint: Constraint{Ordered: true}}})
+	typ := Type{}
+	defaults := MakeDefaultTagValues(typ, templates)
+	if len(defaults) != 0 {
+		t.Errorf("Expected no defaults. Got", defaults)
+	}
+}


### PR DESCRIPTION
This implements the idea described at https://github.com/clipperhouse/typewriter/issues/14.