### PR TITLE
Replace deprecated go tools

### DIFF
--- a/_gen.go
+++ b/_gen.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	_ "github.com/clipperhouse/slice"
 	_ "github.com/clipperhouse/set"
+	_ "github.com/clipperhouse/slice"
 	_ "github.com/clipperhouse/stringer"
 )

--- a/package.go
+++ b/package.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	// gcimporter implements Import for gc-generated files
-	_ "golang.org/x/tools/go/gcimporter"
-	"golang.org/x/tools/go/types"
+	"go/types"
+
+	_ "golang.org/x/tools/go/gcimporter15"
 )
 
 type evaluator interface {

--- a/package_test.go
+++ b/package_test.go
@@ -1,9 +1,8 @@
 package typewriter
 
 import (
+	"go/types"
 	"testing"
-
-	"golang.org/x/tools/go/types"
 )
 
 func TestEval(t *testing.T) {

--- a/predicates.go
+++ b/predicates.go
@@ -9,7 +9,7 @@
 package typewriter
 
 import (
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 func isComparable(typ types.Type) bool {

--- a/template.go
+++ b/template.go
@@ -3,7 +3,6 @@ package typewriter
 import (
 	"fmt"
 	"strings"
-
 	"text/template"
 )
 

--- a/type.go
+++ b/type.go
@@ -2,10 +2,9 @@ package typewriter
 
 import (
 	"fmt"
+	"go/types"
 	"regexp"
 	"strings"
-
-	"golang.org/x/tools/go/types"
 )
 
 type Type struct {


### PR DESCRIPTION
`golang.org/x/tools/go/gcimporter` is not found now.