### PR TITLE
[fix] golang 1.6 imports

### DIFF
--- a/package.go
+++ b/package.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	// gcimporter implements Import for gc-generated files
-	_ "golang.org/x/tools/go/gcimporter"
-	"golang.org/x/tools/go/types"
+	"go/types"
+
+	_ "golang.org/x/tools/go/gcimporter15"
 )
 
 type evaluator interface {

--- a/predicates.go
+++ b/predicates.go
@@ -9,7 +9,7 @@
 package typewriter
 
 import (
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 func isComparable(typ types.Type) bool {

--- a/type.go
+++ b/type.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 type Type struct {


### PR DESCRIPTION
Fix those errors on golang 1.6:

```
cannot find package "golang.org/x/tools/go/gcimporter" in any of:
…
```
here you can found [more information about gcimporter](https://github.com/golang/tools/commit/4747062949bf9494e68ca5ff3443bd094ec9334c)
and 
```
no buildable Go source files in /home/scl/go/src/golang.org/x/tools/go/types
```
as `go/types` is now part of golang sources