### PR TITLE
Fix type resolution under Go 1.6-compiled gen programs.

### DIFF
--- a/package.go
+++ b/package.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 
 	// gcimporter implements Import for gc-generated files
+	"go/importer"
 	"go/types"
-
-	_ "golang.org/x/tools/go/gcimporter15"
 )
 
 type evaluator interface {
@@ -72,6 +71,7 @@ func getPackage(fset *token.FileSet, a *ast.Package, conf *Config) (*Package, *T
 	config := types.Config{
 		DisableUnusedImportCheck: true,
 		IgnoreFuncBodies:         true,
+		Importer:                 importer.Default(),
 	}
 
 	if conf.IgnoreTypeCheckErrors {


### PR DESCRIPTION
This fixes the problem I was having using gen from Go 1.6, for which I filed under https://github.com/clipperhouse/gen/issues/98 -- The problem seems to be that the usage of go/types has changed since 1.5, and this fixes the usage to align with go 1.6.

It's a small, 3-line change, but I'm open for comments on it. :)